### PR TITLE
Encode userinfo fields per RFC 3986

### DIFF
--- a/src/build-url.test.ts
+++ b/src/build-url.test.ts
@@ -399,6 +399,63 @@ describe(buildUrl.name, () => {
         },
     ]);
 
+    itCases(
+        ({username, password}: {username: string; password: string}) => {
+            const result = buildUrl({
+                protocol: 'postgresql',
+                hostname: 'db.example.com',
+                port: 5432,
+                paths: ['mydb'],
+                username,
+                password,
+            });
+
+            return {
+                username: result.username,
+                password: result.password,
+                href: result.href,
+            };
+        },
+        [
+            {
+                it: 'encodes # in password',
+                input: {
+                    username: 'dbuser',
+                    password: 'abc#xyz',
+                },
+                expect: {
+                    username: 'dbuser',
+                    password: 'abc#xyz',
+                    href: 'postgresql://dbuser:abc%23xyz@db.example.com:5432/mydb',
+                },
+            },
+            {
+                it: 'encodes ? in password',
+                input: {
+                    username: 'dbuser',
+                    password: 'pass?word',
+                },
+                expect: {
+                    username: 'dbuser',
+                    password: 'pass?word',
+                    href: 'postgresql://dbuser:pass%3Fword@db.example.com:5432/mydb',
+                },
+            },
+            {
+                it: 'encodes @ in username',
+                input: {
+                    username: 'user@domain',
+                    password: 'pass',
+                },
+                expect: {
+                    username: 'user@domain',
+                    password: 'pass',
+                    href: 'postgresql://user%40domain:pass@db.example.com:5432/mydb',
+                },
+            },
+        ],
+    );
+
     it('handles missing base string input', () => {
         assert.deepEquals(
             buildUrl({

--- a/src/parse-url.test.ts
+++ b/src/parse-url.test.ts
@@ -319,6 +319,44 @@ describe(parseUrl.name, () => {
             },
         },
         {
+            it: 'decodes percent-encoded password',
+            inputs: [
+                'https://user:abc%23xyz@example.com/path',
+            ],
+            expect: {
+                ...emptyUrlParts,
+                fullPath: '/path',
+                host: 'example.com',
+                hostname: 'example.com',
+                href: 'https://user:abc%23xyz@example.com/path',
+                origin: 'https://example.com',
+                password: 'abc#xyz',
+                pathname: '/path',
+                paths: ['path'],
+                protocol: 'https',
+                username: 'user',
+            },
+        },
+        {
+            it: 'decodes percent-encoded username',
+            inputs: [
+                'https://user%40domain:pass@example.com/path',
+            ],
+            expect: {
+                ...emptyUrlParts,
+                fullPath: '/path',
+                host: 'example.com',
+                hostname: 'example.com',
+                href: 'https://user%40domain:pass@example.com/path',
+                origin: 'https://example.com',
+                password: 'pass',
+                pathname: '/path',
+                paths: ['path'],
+                protocol: 'https',
+                username: 'user@domain',
+            },
+        },
+        {
             it: 'handles a simple url',
             inputs: [
                 'https://example.com',
@@ -473,6 +511,34 @@ describe(createHref.name, () => {
                 username: '',
             },
             expect: '/path/1/2?hello=there',
+        },
+        {
+            it: 'encodes special characters in password',
+            input: {
+                hash: '',
+                hostname: 'example.com',
+                port: '',
+                password: 'abc#xyz',
+                pathname: '/',
+                protocol: 'https',
+                search: '',
+                username: 'user',
+            },
+            expect: 'https://user:abc%23xyz@example.com/',
+        },
+        {
+            it: 'encodes special characters in username',
+            input: {
+                hash: '',
+                hostname: 'example.com',
+                port: '',
+                password: 'pass',
+                pathname: '/',
+                protocol: 'https',
+                search: '',
+                username: 'user@domain',
+            },
+            expect: 'https://user%40domain:pass@example.com/',
         },
     ]);
 });

--- a/src/parse-url.ts
+++ b/src/parse-url.ts
@@ -26,8 +26,8 @@ export function createHref({
 >): string {
     return [
         protocol ? protocol + '://' : '',
-        username ? username + ':' : '',
-        password ? password + '@' : '',
+        username ? encodeURIComponent(username) + ':' : '',
+        password ? encodeURIComponent(password) + '@' : '',
         createHost({hostname, port}),
         createFullPath({hash, pathname, search}),
     ].join('');
@@ -160,8 +160,8 @@ export function parseUrl(
         rawPassword,
         ...rawUsernameParts
     ] = hasLogin ? login.split(':').reverse() : [];
-    const username = rawUsernameParts.toReversed().join('').replace(/[/:]/g, '') || '';
-    const password = rawPassword?.replace(/[/:]/g, '') || '';
+    const username = decodeURIComponent(rawUsernameParts.toReversed().join('').replace(/[/:]/g, '') || '');
+    const password = decodeURIComponent(rawPassword?.replace(/[/:]/g, '') || '');
 
     const maybePort = splitIncludeSplit(withoutLogin.replace(/\/.*/, ''), ':', {
         caseSensitive: true,


### PR DESCRIPTION
## Summary

- `createHref` now percent-encodes `username` and `password` with `encodeURIComponent` so URL-special characters (`#`, `?`, `@`, `/`, `%`) don't break the resulting href
- `parseUrl` now decodes these fields with `decodeURIComponent` so `UrlParts` always stores decoded values and round-tripping works correctly

Fixes a bug where `buildUrl` with a password like `abc#xyz` would produce a malformed URL (`postgresql://user:abc#xyz@host`) that parsers interpret as a fragment delimiter, breaking database connection strings and similar use cases.

## Test plan

- [x] New `parseUrl` tests: decodes percent-encoded password and username
- [x] New `createHref` tests: encodes special characters in password and username
- [x] New `buildUrl` tests: encodes `#`, `?`, `@` in userinfo fields, verifies `UrlParts` stores decoded values while `href` contains encoded values
- [x] All existing tests pass unchanged (no existing test data contained special characters in userinfo)
- [x] Tests pass on Chromium, Webkit, and Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)